### PR TITLE
fix: missing role in session token and webcam icon

### DIFF
--- a/purejs-demo/index.html
+++ b/purejs-demo/index.html
@@ -33,7 +33,7 @@
                         <i id="js-preview-mic-icon" class="fas fa-microphone-slash"></i>
                     </button>
                     <button id="js-preview-webcam-button" class="meeting-control-button">
-                        <i id="js-preview-webcam-icon" class="fas fa-video webcam__off"></i>
+                        <i id="js-preview-webcam-icon" class="fas fa-video-slash webcam__off"></i>
                     </button>
                 </div>
             </div>
@@ -57,7 +57,7 @@
                     <i id="js-mic-icon" class="fas fa-microphone-slash"></i>
                 </button>
                 <button id="js-webcam-button" class="meeting-control-button">
-                    <i id="js-webcam-icon" class="fas fa-video webcam__off"></i>
+                    <i id="js-webcam-icon" class="fas fa-video-slash webcam__off"></i>
                 </button>
                 <div class="vertical-divider"></div>
                 <button id="js-leave-button" 

--- a/purejs-demo/src/js/meeting/preview/preview.js
+++ b/purejs-demo/src/js/meeting/preview/preview.js
@@ -115,10 +115,14 @@ const initPreviewButtons = () => {
 
     const initVideoPreviewButtonClick = () => {
         const webcamButton = document.getElementById('js-preview-webcam-button');
-
+        const webcamIcon = document.getElementById('js-preview-webcam-icon');
         let isButtonAlreadyClicked = false;
 
-        const toggleWebcamButtonStyle = () => webcamButton.classList.toggle('meeting-control-button__off');
+        const toggleWebcamButtonStyle = () => {
+            webcamIcon.classList.toggle('fa-video');
+            webcamIcon.classList.toggle('fa-video-slash');
+            webcamButton.classList.toggle('meeting-control-button__off')
+        };
         const togglePreviewVideo = async () => isWebcamOn ? videoTrack.start(PREVIEW_VIDEO_ELEMENT) : videoTrack.stop();
 
         const onClick = async (event) => {

--- a/purejs-demo/src/js/meeting/session-joiner.js
+++ b/purejs-demo/src/js/meeting/session-joiner.js
@@ -27,9 +27,8 @@ const joinSession = async (zmClient) => {
     sessionConfig.topic,
     sessionConfig.password,
     sessionConfig.sessionKey,
-    '',
-    '',
-    uuidv4()
+    sessionConfig.user_identity,
+    sessionConfig.role
   );
 
   let mediaStream;

--- a/purejs-demo/src/js/meeting/session/button-click-handlers.js
+++ b/purejs-demo/src/js/meeting/session/button-click-handlers.js
@@ -82,11 +82,16 @@ const initButtonClickHandlers = async (zoomClient, mediaStream) => {
   // At that point, video should be rendered. The reverse is true for stopping video
   const initWebcamClick = () => {
     const webcamButton = document.getElementById('js-webcam-button');
+    const webcamIcon = document.getElementById('js-webcam-icon');
 
     let isWebcamOn = false;
     let isButtonAlreadyClicked = false;
 
-    const toggleWebcamButtonStyle = () => webcamButton.classList.toggle('meeting-control-button__off');
+    const toggleWebcamButtonStyle = () => {
+      webcamIcon.classList.toggle('fa-video');
+      webcamIcon.classList.toggle('fa-video-slash');
+      webcamButton.classList.toggle('meeting-control-button__off');
+    };
 
     const onClick = async (event) => {
       event.preventDefault();


### PR DESCRIPTION
In [`purejs-demo/src/js/meeting/session-joiner.js`](https://github.com/zoom/videosdk-web-sample/compare/master...EkaanshArora:videosdk-web-sample:patch-ekaansh?expand=1#diff-eee030e2d2c7a56a0f815b8f3df108700c6054a867aa1f6158afca0de5b5d8c5) an empty string was being passed to the `generateSessionToken` function. This fix forwards the correct parameter from the config.

I also added the video icon to follow the same (slashed) behaviour as the mic icon for consistency.